### PR TITLE
Fix for shiboleth authentication with CSP

### DIFF
--- a/popupsconfig/main.js
+++ b/popupsconfig/main.js
@@ -14,6 +14,26 @@ function initPopupsConfiguration(jitsiMeetWindow) {
         popupsConfigRegistry.registerPopupConfigs(configs);
     });
 
+    // Remove X-Frame-Option and CSP frame-anchestor headers from responses, to
+    // allow us to show login pages from the server, even if it sets those
+    // headers. This is for example often needed for Shiboleth authentication.
+    var onHeadersReceived=(detail, callback) => {
+        const xFrameOriginKey = Object.keys(detail.responseHeaders).find(
+          header => String(header).match(/^x-frame-options$/i));
+        const cspKey = Object.keys(detail.responseHeaders).find(
+          header => String(header).match(/^content-security-policy$/i));
+        if (xFrameOriginKey) {
+            delete detail.responseHeaders[xFrameOriginKey];
+        }
+        if (cspKey) {
+            detail.responseHeaders[cspKey] = detail.responseHeaders[cspKey]
+                .toString().replace(/frame-ancestors [^;]*;/, "");
+        }
+        callback({cancel: false, responseHeaders: detail.responseHeaders});
+    }
+    jitsiMeetWindow.webContents.session.webRequest.onHeadersReceived(
+        onHeadersReceived);
+
     // Configuration for the google auth popup.
     jitsiMeetWindow.webContents.on('new-window', (
             event,


### PR DESCRIPTION
This commit removes CSP frame-anchestor and x-frame-option from
response headers. This prevents electron from blocking server side
sign-in (such as Shiboleth/SAML authentication) with those headers.