### PR TITLE
fix(content-protection): Fix content protection on Windows.

### DIFF
--- a/alwaysontop/main.js
+++ b/alwaysontop/main.js
@@ -1,6 +1,6 @@
 const os = require('os');
 const electron = require('electron');
-const robot = require("robotjs");
+const robot = require('robotjs');
 const { BrowserWindow, ipcMain } = electron;
 const { SIZE } = require('./constants');
 const log = require('jitsi-meet-logger');
@@ -80,13 +80,18 @@ function onAlwaysOnTopWindow(
         // Required to allow the window to be rendered on top of full screen apps
         win.setAlwaysOnTop(true, 'screen-saver');
 
-        // Avoid this window from being captured.
-        win.setContentProtection(true);
+        // Once this bug is fixed on Electron side we'll re-enable this for Windows 10 Version 2004 or newer:
+        // https://github.com/electron/electron/issues/29085
+        if (os.platform() !== 'win32') {
+            logInfo('setContentProtection');
+            // Avoid this window from being captured.
+            win.setContentProtection(true);
+        }
 
         //the renderer process tells the main process to close the BrowserWindow
         //this is needed when open and close AOT are called in quick succession on renderer process.
         ipcMain.once('jitsi-always-on-top-should-close', () => {
-            logInfo("jitsi-always-on-top-should-close");
+            logInfo('jitsi-always-on-top-should-close');
             if (win && !win.isDestroyed()) {
                 logInfo('jitsi-always-on-top-should-close: closing window');
                 win.close();

--- a/helpers/functions.js
+++ b/helpers/functions.js
@@ -1,0 +1,42 @@
+/**
+ * Compares two versions.
+ * 
+ * @param {*} oldVer - the previous version.
+ * @param {*} newVer - the newer version.
+ * @returns {boolean} - whether the new version is higher or equal to old version.
+ */
+const isVersionNewerOrEqual = (oldVer, newVer) => {
+    try {
+        const oldParts = oldVer.split('.');
+        const newParts = newVer.split('.');
+        for (let i = 0; i < newParts.length; i++) {
+            const a = parseInt(newParts[i]);
+            const b = parseInt(oldParts[i]);
+            if (a > b) return true;
+            if (a < b) return false;
+        }
+        return true;
+    } catch (e) {
+        return false;
+    }
+};
+
+/**
+ * This is the Windows release which introduced WDA_EXCLUDEFROMCAPTURE (Windows 10 Version 2004),
+ * which is used by Electron to hide the window on screen captures. For older Windows OS's WDA_MONITOR flag is used,
+ * which shows a black screen on screen captures.
+ * https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity
+ */
+const HIDE_SCREEN_CAPTURE_WINDOWS_RELEASE = '10.0.19041';
+
+/**
+ * Enable screen capture protection only for Windows versions newer or equal to Windows 10 Version 2004.
+ * 
+ * @param {string} currentVer - current OS version.
+ * @returns {boolean} - whether the given version is equal or newer than the Windows 10 Version 2004 release.
+ */
+const windowsEnableScreenProtection = currentVer => isVersionNewerOrEqual(HIDE_SCREEN_CAPTURE_WINDOWS_RELEASE, currentVer);
+
+module.exports = {
+    windowsEnableScreenProtection
+};


### PR DESCRIPTION
- disable content protection for Windows AOT.
- for Windows, only enable content protection for latest Windows versions for screensharing browser window.

Disabled content protection for AOT on Windows until this bug is fixed:
https://github.com/electron/electron/issues/29085

For screensharing on Windows we only enable it for Windows 10 Version 2004 or newer, because older versions of Windows use `WDA_MONITOR` instead of `WDA_EXCLUDEFROMCAPTURE`, which makes the window visible but with black content:
https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwindowdisplayaffinity
