### PR TITLE
3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jitsi/electron-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jitsi/electron-sdk",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jitsi/electron-sdk",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Utilities for jitsi-meet-electron project",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- fix(ci): only publish with one matrix build to npm (#150)
- fix: use napi also during normal package install (#152)
- chore(deps): update robotjs to use prebuilds during npm install (#154)
- fixup repository url in package.json (#151)
- README: Add publishing docs (#153)