### PR TITLE
fix(aot-breakout) Prevent `videoConferenceJoined` handler being calle…

### DIFF
--- a/alwaysontop/render/index.js
+++ b/alwaysontop/render/index.js
@@ -44,6 +44,7 @@ class AlwaysOnTop extends EventEmitter {
         this._onStateChange = this._onStateChange.bind(this);
         this._switchToMainWindow = this._switchToMainWindow.bind(this);
         this._updateLargeVideoSrc = this._updateLargeVideoSrc.bind(this);
+        this._alreadyJoined = false;
 
         this._api.on('_willDispose', this._closeWindow);
         this._api.on('videoConferenceJoined', this._onConferenceJoined);
@@ -72,6 +73,11 @@ class AlwaysOnTop extends EventEmitter {
     }
 
     _onConferenceJoined() {
+        if (this._alreadyJoined) {
+            return;
+        }
+
+        this._alreadyJoined = true;
         ipcRenderer.on(EVENTS.UPDATE_STATE, this._onStateChange);
 
         sendStateUpdate(STATES.CONFERENCE_JOINED);
@@ -208,6 +214,8 @@ class AlwaysOnTop extends EventEmitter {
             this._aotWindow.close();
             this._aotWindow = null;
         }
+
+        this._alreadyJoined = false;
     }
 
     /**


### PR DESCRIPTION
…d multiple times

- When joining breakout rooms, a new `videoConferenceJoined` is triggered. Also yet another `videoConferenceJoined`
is triggered when leaving the breakout room. This seem to cause at least the onBlur handler not to be removed,
thus onBlur gets called after the meeting was left, which creates a new AOT window.