### PR TITLE
fix(aot) Fix intersection; fix conference left

### DIFF
--- a/alwaysontop/constants.js
+++ b/alwaysontop/constants.js
@@ -22,8 +22,8 @@ module.exports = {
         OPEN: 'aot-open',
         SHOW: 'aot-show',
         SHOW_MAIN_WINDOW: 'aot-main-window-show',
-        SHOW_AOT_WINDOW: 'show-aot-window',
-        HIDE_AOT_WINDOW: 'hide-aot-window'
+        IS_NOT_INTERSECTING: 'is-not-intersecting',
+        IS_INTERSECTING: 'is-intersecting'
     },
     STORAGE: {
         AOT_X: 'aot-x',

--- a/alwaysontop/main/index.js
+++ b/alwaysontop/main/index.js
@@ -27,6 +27,11 @@ let aotWindow;
 let mainWindow;
 
 /**
+ * Whether the meeting is currently in view.
+ */
+let isIntersecting;
+
+/**
  * Sends an update state event to renderer process
  * @param {string} value the updated aot window state
  */
@@ -110,8 +115,10 @@ const showAot = () => {
  */
  const hideAot = () => {
     logInfo('hide aot handler');
-
-    hideWindow();
+    if (isIntersecting) {
+        logInfo('is intersecting. hiding');
+        hideWindow();
+    }
 };
 
 /**
@@ -194,10 +201,12 @@ const onStateChange = (event, { value }) => {
             // this will switch focus to main window, which in turns triggers hide on aot
             mainWindow.show();
             break;
-        case STATES.SHOW_AOT_WINDOW:
+        case STATES.IS_NOT_INTERSECTING:
+            isIntersecting = false;
             showAot();
             break;
-        case STATES.HIDE_AOT_WINDOW:
+        case STATES.IS_INTERSECTING:
+            isIntersecting = true;
             hideAot();
             break;
         default:


### PR DESCRIPTION
- Now focus handler also checks whether the meeting is intersecting before hiding AOT
- Now on conference left we do not remove the listeners because it not always means that meeting ended.
This fixes cases when we have a passcode/lobby and also breakout rooms when conferenceLeft and joined are called
during the same meeting session.