### PR TITLE
fix(screenshare): adapt to electron 17+ desktopCapturer.getSources

### DIFF
--- a/screensharing/constants.js
+++ b/screensharing/constants.js
@@ -5,6 +5,12 @@
 const SCREEN_SHARE_EVENTS_CHANNEL = 'jitsi-screen-sharing-marker';
 
 /**
+ * The name of the channel that returns desktopCapturer.getSources
+ * @type {string}
+ */
+const SCREEN_SHARE_GET_SOURCES = 'jitsi-screen-sharing-get-sources';
+
+/**
  * Size of the screen sharing tracker window.
  */
 const TRACKER_SIZE = {
@@ -25,6 +31,7 @@ const SCREEN_SHARE_EVENTS = {
 module.exports = {
     SCREEN_SHARE_EVENTS_CHANNEL,
     SCREEN_SHARE_EVENTS,
+    SCREEN_SHARE_GET_SOURCES,
     TRACKER_SIZE
 };
 

--- a/screensharing/render.js
+++ b/screensharing/render.js
@@ -1,7 +1,7 @@
 
-const { ipcRenderer, desktopCapturer } = require('electron');
+const { ipcRenderer } = require('electron');
 
-const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS } = require('./constants');
+const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS, SCREEN_SHARE_GET_SOURCES } = require('./constants');
 
 /**
  * Renderer process component that sets up electron specific screen sharing functionality, like screen sharing
@@ -51,8 +51,7 @@ class ScreenShareRenderHook {
              * 150px.
              */
             obtainDesktopStreams(callback, errorCallback, options = {}) {
-                desktopCapturer
-                    .getSources(options)
+                ipcRenderer.invoke(SCREEN_SHARE_GET_SOURCES, options)
                     .then((sources) => callback(sources))
                     .catch((error) => errorCallback(error));
             }


### PR DESCRIPTION
Starting with electron 17, desktopCapturer.getSources(options) is
only available on the main process, not the renderer.

See https://www.electronjs.org/docs/latest/breaking-changes#removed-desktopcapturergetsources-in-the-renderer
