### PR TITLE
fix(aot) Remove main window close handler

### DIFF
--- a/alwaysontop/main/index.js
+++ b/alwaysontop/main/index.js
@@ -122,15 +122,6 @@ const showAot = () => {
 };
 
 /**
- * Handle close event on main window
- */
-const onClose = () => {
-    logInfo('handling main window close');
-
-    closeWindow();
-};
-
-/**
  * Attaches event handlers on the main window
  */
 const addWindowHandlers = () => {
@@ -138,9 +129,6 @@ const addWindowHandlers = () => {
 
     mainWindow.on('blur', showAot);
     mainWindow.on('focus', hideAot);
-
-    // this might be redundant, since child windows will be closed anyway
-    mainWindow.on('close', onClose);
 };
 
 /**
@@ -151,7 +139,6 @@ const removeWindowHandlers = () => {
 
     mainWindow.removeListener('blur', showAot);
     mainWindow.removeListener('focus', hideAot);
-    mainWindow.removeListener('close', onClose);
 };
 
 


### PR DESCRIPTION
This fixes an issue where in case the main window handles the `close` event and does preventDefault() so it dismisses the close, AOT window will close, which causes 2 issues:
-  AOT will not show up anymore for the ongoing meeting
-  when the meeting ends, the `_onConferenceLeft` from renderer will try to close AOT window again, but will crash since AOT is already closed.