### PR TITLE
refactor: guard and build native code only on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,15 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
-            arch: x64
-            build-group: linux-x64
-          - os: macos-11
-            arch: x64
-            build-group: darwin-universal
-          - os: macos-11
-            arch: x64
-            build-group: darwin-x64
           - os: windows-2019
             arch: x86
             build-group: win32-x86

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install from npm:
 
     npm install @jitsi/electron-sdk
 
-Note: This package contains native code for the remote control module. Binary prebuilds are downloaded during install for Windows x64 and ia32, Linux x64 and Mac x64 and arm64.
+Note: This package contains native code on Windows for the remote control module. Binary prebuilds are packaged with prebuildify as part of the npm package.
 
 ## Usage
 #### Remote Control

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,18 +3,6 @@
         'target_name': 'sourceId2Coordinates',
         'cflags!': [ '-fno-exceptions' ],
         'cflags_cc!': [ '-fno-exceptions' ],
-        'xcode_settings': { 'GCC_ENABLE_CPP_EXCEPTIONS': 'YES',
-          'CLANG_CXX_LIBRARY': 'libc++',
-          'MACOSX_DEPLOYMENT_TARGET': '10.7',
-          'OTHER_CFLAGS': [
-            '-arch x86_64',
-            '-arch arm64'
-          ],
-          'OTHER_LDFLAGS': [
-            '-arch x86_64',
-            '-arch arm64'
-          ]
-        },
         'msvs_settings': {
           'VCCLCompilerTool': { 'ExceptionHandling': 1 },
         },

--- a/install.js
+++ b/install.js
@@ -1,0 +1,9 @@
+const { spawnSync } = require('child_process');
+const process = require('process');
+
+if (process.platform === 'win32') {
+	spawnSync('npm.cmd', ['run', 'node-gyp-build'], {
+		input: 'win32 detected. Ensure native code prebuild or rebuild it',
+		stdio: 'inherit'
+	});
+}

--- a/package.json
+++ b/package.json
@@ -7,10 +7,8 @@
     "lint": "eslint .",
     "test": "TESTING=true mocha",
     "validate": "npm ls",
-    "install": "node-gyp-build",
-    "prebuild-darwin-universal": "prebuildify -t 16.0.0 --napi --strip --arch x64+arm64",
-    "prebuild-darwin-x64": "prebuildify -t 16.0.0 --napi --strip --arch x64 && lipo -remove arm64 prebuilds/darwin-x64/node.napi.node -output prebuilds/darwin-x64/node.napi.node",
-    "prebuild-linux-x64": "prebuildify -t 16.0.0 --napi --strip",
+    "install": "node install.js",
+    "node-gyp-build": "node-gyp-build",
     "prebuild-win32-x86": "prebuildify -t 16.0.0 --napi --strip",
     "prebuild-win32-x64": "prebuildify -t 16.0.0 --napi --strip"
   },

--- a/test/sourceId2Coordinates.test.js
+++ b/test/sourceId2Coordinates.test.js
@@ -1,13 +1,16 @@
-const sourceId2Coordinates = require('../node_addons/sourceId2Coordinates');
 const assert = require('assert');
+const process = require('process');
 
 
 describe('sourceId2Coordinates', () => {
     describe('native_addon', () => {
         it('returns undefined for fake value', () => {
-            const result = sourceId2Coordinates("foo");
+            if (process.platform === 'win32') {
+                const sourceId2Coordinates = require('../node_addons/sourceId2Coordinates');
+                const result = sourceId2Coordinates("foo");
 
-            assert.equal(undefined, result);
+                assert.equal(undefined, result);
+            }
         });
     });
 });


### PR DESCRIPTION
the native code anyway only is required and supports windows
