### PR TITLE
fix(ScreenSharingTracker) use a preload script

### DIFF
--- a/screensharing/main.js
+++ b/screensharing/main.js
@@ -2,6 +2,7 @@
 const { exec } = require('child_process');
 const electron = require('electron');
 const os = require('os');
+const path = require('path');
 
 const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS, SCREEN_SHARE_GET_SOURCES, TRACKER_SIZE } = require('./constants');
 const { isMac } = require('./utils');
@@ -95,7 +96,8 @@ class ScreenShareMainHook {
         }
 
         // Display always on top screen sharing tracker window in the center bottom of the screen.
-        let display = electron.screen.getPrimaryDisplay();
+        const display = electron.screen.getPrimaryDisplay();
+
         this._screenShareTracker = new electron.BrowserWindow({
             height: TRACKER_SIZE.height,
             width: TRACKER_SIZE.width,
@@ -112,10 +114,9 @@ class ScreenShareMainHook {
             frame: false,
             show: false,
             webPreferences: {
-                // TODO: these 3 should be removed.
-                contextIsolation: false,
-                enableRemoteModule: true,
-                nodeIntegration: true
+                contextIsolation: true,
+                nodeIntegration: false,
+                preload: path.resolve(__dirname, './preload.js')
             }
         });
 

--- a/screensharing/preload.js
+++ b/screensharing/preload.js
@@ -1,0 +1,16 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS } = require('./constants');
+
+contextBridge.exposeInMainWorld('JitsiScreenSharingTracker', {
+    EVENTS: SCREEN_SHARE_EVENTS,
+    sendEvent: ev => {
+        if (Object.values(SCREEN_SHARE_EVENTS).includes(ev)) {
+            ipcRenderer.send(SCREEN_SHARE_EVENTS_CHANNEL, {
+                data: {
+                    name: ev
+                }
+            });
+        }
+    }
+});

--- a/screensharing/screenSharingTracker.js
+++ b/screensharing/screenSharingTracker.js
@@ -1,23 +1,16 @@
-const { ipcRenderer } = require('electron');
-const querystring = require('querystring');
-
-const { SCREEN_SHARE_EVENTS_CHANNEL, SCREEN_SHARE_EVENTS } = require('./constants');
-
 const screenShareStop = document.getElementById("screen-share-marker-stop");
 const screenShareMinimize = document.getElementById("screen-share-marker-minimize");
 const sharingIdentity = document.getElementById("sharing-identity");
 
-sharingIdentity.innerHTML = querystring.parse(global.location.search)['?sharingIdentity'];
+sharingIdentity.innerText = new URL(window.location).searchParams.get('sharingIdentity');
+
+const { EVENTS, sendEvent } = window.JitsiScreenSharingTracker;
 
 /**
  * Minimize the window.
  */
 screenShareMinimize.addEventListener("click", function() {
-    ipcRenderer.send(SCREEN_SHARE_EVENTS_CHANNEL, {
-        data: {
-            name: SCREEN_SHARE_EVENTS.HIDE_TRACKER
-        }
-    });
+    sendEvent(EVENTS.HIDE_TRACKER);
 });
 
 /**
@@ -25,10 +18,5 @@ screenShareMinimize.addEventListener("click", function() {
  * {@link ScreenShareRenderHook} which will toggle the screen sharing session using the jitsi-meet api.
  */
 screenShareStop.addEventListener("click", function() {
-    ipcRenderer.send(SCREEN_SHARE_EVENTS_CHANNEL, {
-        data: {
-            name: SCREEN_SHARE_EVENTS.STOP_SCREEN_SHARE
-        }
-    });
+    sendEvent(EVENTS.STOP_SCREEN_SHARE);
 });
-


### PR DESCRIPTION
- Enable context isolation for this window
- Add a preload script
- Disable unnecessary Node integration
- Sanitize query parameter handling