### PR TITLE
fix: downgrade node-gyp-build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@jitsi/robotjs": "^0.6.9",
         "electron-store": "^8.0.1",
         "node-addon-api": "^5.0.0",
-        "node-gyp-build": "^4.5.0",
+        "node-gyp-build": "4.3.0",
         "postis": "^2.2.0"
       },
       "devDependencies": {
@@ -1663,9 +1663,9 @@
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
     },
     "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -3697,9 +3697,9 @@
       "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
     },
     "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.3.0.tgz",
+      "integrity": "sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@jitsi/robotjs": "^0.6.9",
     "electron-store": "^8.0.1",
     "node-addon-api": "^5.0.0",
-    "node-gyp-build": "^4.5.0",
+    "node-gyp-build": "4.3.0",
     "postis": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts 818cd55feb3bcdead9e8128cc3b9d6aaf527fb39

See compile failures as prebuilds on windows are no longer used
eg. here https://github.com/jitsi/jitsi-meet-electron/runs/7639735746?check_suite_focus=true
