### PR TITLE
fix(ci): autopublish v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,15 @@ jobs:
       with:
         name: prebuilds
         path: prebuilds
-    - uses: jitsi/gh-action-autopublish@master
+    - uses: phips28/gh-action-bump-version@608cab1205a5560a93eb66b4a64e4acf2119597b
+      with:
+        tag-prefix: 'v'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm publish --access public
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
jitsi/gh-action-autopublish does not work, as it tries to do npm install,
which will fail due to binary dependencies (robotjs) in the docker
container of jitsi/gh-action-autopublish
