### PR TITLE
chore(build) prevent accidental pushes to master

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "master" ]; then
+  echo "You can't commit directly to master branch"
+  exit 1
+fi
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "eslint": ">=3",
         "eslint-plugin-jsdoc": "*",
+        "husky": "^8.0.1",
         "mocha": "^10.0.0",
         "prebuildify": "^5.0.0",
         "precommit-hook": "3.0.0"
@@ -1236,6 +1237,21 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "node_modules/husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -3381,6 +3397,12 @@
           "dev": true
         }
       }
+    },
+    "husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "install": "node install.js",
     "node-gyp-build": "node-gyp-build",
     "prebuild-win32-x86": "prebuildify -t 16.0.0 --napi --strip",
-    "prebuild-win32-x64": "prebuildify -t 16.0.0 --napi --strip"
+    "prebuild-win32-x64": "prebuildify -t 16.0.0 --napi --strip",
+    "prepare": "husky install"
   },
   "pre-commit": [
     "lint"
@@ -44,6 +45,7 @@
   "devDependencies": {
     "eslint": ">=3",
     "eslint-plugin-jsdoc": "*",
+    "husky": "^8.0.1",
     "mocha": "^10.0.0",
     "prebuildify": "^5.0.0",
     "precommit-hook": "3.0.0"


### PR DESCRIPTION
The auto-release bot should still work since it doesn't install the
pre-commit hook.

Sample run:

```
$ git push --dry-run 
You can't commit directly to master branch
husky - pre-push hook exited with code 1 (error)
error: failed to push some refs to 'github.com:jitsi/jitsi-meet-electron-utils.git'
```