### PR TITLE
fix(build): Disable autoinstall and document husky instead 

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ For examples of installation and usage checkout the [Jitsi Meet Electron](https:
 
 ## Development
 
+Enable husky to avoid accidental pushes to the main branch:
+
+    npx husky install
+
 To rebuild the native code, use:
 
     npx node-gyp rebuild

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "node-gyp-build": "node-gyp-build",
     "prebuild-win32-x86": "prebuildify -t 16.0.0 --napi --strip",
     "prebuild-win32-x64": "prebuildify -t 16.0.0 --napi --strip",
-    "prepare": "husky install"
+    "postinstall": "husky install"
   },
   "pre-commit": [
     "lint"

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "install": "node install.js",
     "node-gyp-build": "node-gyp-build",
     "prebuild-win32-x86": "prebuildify -t 16.0.0 --napi --strip",
-    "prebuild-win32-x64": "prebuildify -t 16.0.0 --napi --strip",
-    "postinstall": "husky install"
+    "prebuild-win32-x64": "prebuildify -t 16.0.0 --napi --strip"
   },
   "pre-commit": [
     "lint"


### PR DESCRIPTION
Avoid the prepare step, which also runs when publishing.