### PR TITLE
ci: only one autopublish at once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - master
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build ${{ matrix.build-group }}


### PR DESCRIPTION
Avoid failures like https://github.com/jitsi/jitsi-meet-electron-sdk/actions/runs/3221094393