### PR TITLE
fix(aot) Fix crash on open AOT when a file choose dialog is opened

### DIFF
--- a/alwaysontop/render/index.js
+++ b/alwaysontop/render/index.js
@@ -303,7 +303,13 @@ class AlwaysOnTop extends EventEmitter {
                 this._hideWindow();
                 break;
             case STATES.OPEN:
-                this._openNewWindow(data.aotMagic);
+                try {
+                    this._openNewWindow(data.aotMagic);
+                } catch(e) {
+                    this._api.removeListener('largeVideoChanged', this._updateLargeVideoSrc);
+                    this._api.removeListener('prejoinVideoChanged', this._updateLargeVideoSrc);
+                    this._api.removeListener('videoMuteStatusChanged', this._updateLargeVideoSrc);
+                }
                 break;
             case STATES.SHOW:
                 this._showWindow();


### PR DESCRIPTION
- was able to reproduce on Windows only
- was reproducible with Jitsi Electron app and another jitsi-based app
- error: window.open blocked due to active file chooser. when AOT tries to open (window.open) while the open file dialog is shown