### PR TITLE
fix: Make AOT window be on top of fullscreen apps on MacOS 14

### DIFF
--- a/alwaysontop/main/config.js
+++ b/alwaysontop/main/config.js
@@ -1,6 +1,7 @@
 const { SIZE } = require("../constants");
 
 module.exports = {
+    type: 'panel',
     backgroundColor: 'transparent',
     minWidth: SIZE.width,
     minHeight: SIZE.height,


### PR DESCRIPTION
Hey there. I've noticed that AOT window doesn't stay on top of full-screen apps on macOS Sonoma (v14.2.1).
Not sure if it's the same on lower versions and/or Windows, but setting `type: 'panel'` for created `BrowserWindow` resolves the issue for me

