### PR TITLE
ci: update to v4 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '20.12.1' # pin until https://github.com/prebuild/node-gyp-build/issues/68 is fixed and release
         architecture: ${{ matrix.arch }}
     - run: npm ci
     - run: npm run lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,8 @@ jobs:
         architecture: ${{ matrix.arch }}
     - run: npm ci
     - run: npm run lint
-    - run: TESTING=true npx mocha
+    - run: npm run node-gyp-build
+    - run: npm run test
       shell: bash
     - name: Prebuildify
       run: npm run prebuild-$BUILD_GROUP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         architecture: ${{ matrix.arch }}
     - run: npm ci
     - run: npm run lint
-    - run: npm run test
+    - run: TESTING=true npx mocha
       shell: bash
     - name: Prebuildify
       run: npm run prebuild-$BUILD_GROUP

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,10 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '20.12.1'
         architecture: ${{ matrix.arch }}
     - run: npm ci
     - run: npm run lint
-    - run: npm run node-gyp-build
     - run: npm run test
       shell: bash
     - name: Prebuildify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
     - name: Prebuildify
       run: npm run prebuild-$BUILD_GROUP
       shell: bash
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
-        name: prebuilds
+        name: prebuilds-${{ matrix.build-group }}
         path: prebuilds/
   publish:
     name: Publish to npm
@@ -48,10 +48,11 @@ jobs:
       group: ${{ github.ref }}
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: prebuilds
-        path: prebuilds
+        pattern: prebuilds-*
+        merge-multiple: true
     - uses: phips28/gh-action-bump-version@56588a3c4a1d62a068f308dfbc17f4ee55c69d41
       with:
         tag-prefix: 'v'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20.12.1'
+        node-version: '20'
         architecture: ${{ matrix.arch }}
     - run: npm ci
     - run: npm run lint

--- a/install.js
+++ b/install.js
@@ -4,6 +4,7 @@ const process = require('process');
 if (process.platform === 'win32') {
 	spawnSync('npm.cmd', ['run', 'node-gyp-build'], {
 		input: 'win32 detected. Ensure native code prebuild or rebuild it',
+		shell: true,
 		stdio: 'inherit'
 	});
 }


### PR DESCRIPTION
the upload action no longer allows "appending" to the same name, so merge on download as described https://github.com/actions/download-artifact?tab=readme-ov-file#download-multiple-filtered-artifacts-to-the-same-directory