### PR TITLE
deps: bump node-gyp-build to build on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: '20.12.1' # pin until https://github.com/prebuild/node-gyp-build/issues/68 is fixed and release
+        node-version: '20'
         architecture: ${{ matrix.arch }}
     - run: npm ci
     - run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@jitsi/robotjs": "^0.6.13",
         "electron-store": "^8.0.1",
         "node-addon-api": "^8.0.0",
-        "node-gyp-build": "4.8.0",
+        "node-gyp-build": "4.8.1",
         "postis": "^2.2.0"
       },
       "devDependencies": {
@@ -1820,9 +1820,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -3969,9 +3969,9 @@
       "integrity": "sha512-ipO7rsHEBqa9STO5C5T10fj732ml+5kLN1cAG8/jdHd56ldQeGj3Q7+scUS+VHK/qy1zLEwC4wMK5+yM0btPvw=="
     },
     "node-gyp-build": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
-      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og=="
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.1.tgz",
+      "integrity": "sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw=="
     },
     "normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@jitsi/robotjs": "^0.6.13",
     "electron-store": "^8.0.1",
     "node-addon-api": "^8.0.0",
-    "node-gyp-build": "4.8.0",
+    "node-gyp-build": "4.8.1",
     "postis": "^2.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Required because of https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
