### PR TITLE
ci: pin to windows-2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-latest
+          - os: windows-2022
             arch: x86
             build-group: win32-x86
-          - os: windows-latest
+          - os: windows-2022
             arch: x64
             build-group: win32-x64
           - os: windows-11-arm


### PR DESCRIPTION
It fails with newer visual studio compilers in windows-latest, so pin to old version