### PR TITLE
ci(bump): source the version bump policy from the shared action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,9 @@ jobs:
         path: prebuilds
         pattern: prebuilds-*
         merge-multiple: true
-    - uses: phips28/gh-action-bump-version@215e27a882516826c59df7f09da8c67d5f375cbd
+    - uses: jitsi/gh-actions/npm-version-bump@066f0d506761c59a0ba4aa26c06468d265f07a3c  # npm-version-bump/v1.0.0
       with:
         tag-prefix: 'v'
-        version-type:  'patch'
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6


### PR DESCRIPTION
## Summary

Follow-up to the wordings fix wave (jitsi/js-utils#149 and siblings): the escalation policy now lives in [`npm-version-bump` in jitsi/gh-actions](https://github.com/jitsi/gh-actions/tree/master/npm-version-bump) — a composite wrapper around the same pinned `phips28/gh-action-bump-version` with `major-wording: 'BREAKING CHANGE'` / `minor-wording: 'feat:,feat('` baked in (deliberately not overridable), a CI suite that replays the dependabot-footer incident as a permanent regression test, and dependabot proposing upstream updates in one reviewed place for the whole org.

This swaps the inline config for the shared action, pinned by SHA (npm-version-bump/v1.0.0).

Per review: the hardcoded `version-type: 'patch'` override — this repo's 2022 workaround (f9e6319) for the same dependabot-wording problem — is dropped, so releases here follow the same deliberate-marker policy as the rest of the ecosystem (`BREAKING CHANGE` footer / `type!:` → major, `feat:` prefix → minor, everything else → patch). `tag-prefix: 'v'` stays.

## Test plan

- YAML validated locally.
- The shared action's own CI is green: composite-wiring smoke test + 7 replayed-event behavior cases.
- The commit message avoids all trigger words; the merge itself is the live test and should produce a patch bump.

> Merge note: please rebase-merge keeping the commit message as-is.
